### PR TITLE
try/except around json_loads_url for iiif url

### DIFF
--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -231,9 +231,15 @@ def getHostedContentFile(structmap):
                                                 structmap['id'])
         if iiif_url.startswith('//'):
             iiif_url = ''.join(['http:', iiif_url])
-        iiif_info = json_loads_url(iiif_url)
+
+        try:
+            iiif_info = json_loads_url(iiif_url)
+        except:
+            return None
+
         if not iiif_info:
             return None
+
         size = iiif_info.get('sizes', [])[-1]
         if size['height'] > size['width']:
             access_size = {


### PR DESCRIPTION
Not finding the IIIF info at a working IIIF server is different than the IIIF server not responding, which I found when trying to test this PR by modifying the `UCLDC_IIIF` env variable (`json_loads_url` threw an exception). Seems like if the server isn't responding, we still want this fallback to the thumbnail. 

Ultimately to test the PR, I added a `iiif_url = iiif_url[:-1]` prior to `json_loads_url` in the view function. 